### PR TITLE
Add format to cliOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 |env|`null`|`"env": "mocha"` or `"env": ["mocha", "other"]`
 |ext|`[".js"]`|`"ext": ".jsx"` or `"ext": [".jsx", ".ts"]`
 |fix|`false`|`"fix": true`
+|format|`null`|`"format": "codeframe"`
 |global|`[]`|`"global": "it"` or `"global": ["it", "describe"]`
 |ignorePath|`null`|`"ignorePath": "/path/to/ignore"`
 |noEslintrc|`false`|`"noEslintrc": true`

--- a/integrationTests/__fixtures__/format/__eslint__/file.js
+++ b/integrationTests/__fixtures__/format/__eslint__/file.js
@@ -1,0 +1,6 @@
+const a = 1;
+
+if (a === 2) {
+  hello();
+  bye();
+}

--- a/integrationTests/__fixtures__/format/jest-runner-eslint.config.js
+++ b/integrationTests/__fixtures__/format/jest-runner-eslint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cliOptions: {
+    format: 'codeframe',
+  },
+};

--- a/integrationTests/__fixtures__/format/jest.config.js
+++ b/integrationTests/__fixtures__/format/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  runner: '../../../',
+  testMatch: ['**/__eslint__/**/*.js'],
+};

--- a/integrationTests/__snapshots__/format.test.js.snap
+++ b/integrationTests/__snapshots__/format.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Applies custom formatter 1`] = `
+"FAIL integrationTests/__fixtures__/format/__eslint__/file.js
+      at mocked-stack-trace  2 |
+  3 | if (a === 2) {
+> 4 |   hello();
+    |   ^
+  5 |   bye();
+  6 | }
+  7 |
+mocked-stack-trace  3 | if (a === 2) {
+  4 |   hello();
+> 5 |   bye();
+    |   ^
+  6 | }
+  7 |
+2 errors found.
+  ✕ ESLint
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:
+Ran all test suites.
+
+"
+`;

--- a/integrationTests/format.test.js
+++ b/integrationTests/format.test.js
@@ -1,0 +1,5 @@
+const runJest = require('./runJest');
+
+it('Applies custom formatter', () => {
+  return expect(runJest('format')).resolves.toMatchSnapshot();
+});

--- a/src/runESLint.js
+++ b/src/runESLint.js
@@ -78,7 +78,7 @@ const runESLint = ({ testPath, config }, workerCallback) => {
       const end = +new Date();
 
       if (report.errorCount > 0) {
-        const formatter = cli.getFormatter();
+        const formatter = cli.getFormatter(options.cliOptions.format);
         const errorMessage = formatter(
           CLIEngine.getErrorResults(report.results),
         );

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -23,6 +23,9 @@ const BASE_CONFIG = {
   fix: {
     default: false,
   },
+  format: {
+    default: null
+  },
   global: {
     name: 'globals',
     default: [],


### PR DESCRIPTION
Allows passing a [custom formatter](https://eslint.org/docs/user-guide/formatters/) to ESLint. 