### PR TITLE
Add support for setupTestFrameworkScriptFile option.

### DIFF
--- a/src/runESLint.js
+++ b/src/runESLint.js
@@ -62,6 +62,11 @@ const pass = ({ start, end, testPath }) =>
 const runESLint = ({ testPath, config }, workerCallback) => {
   try {
     const start = +new Date();
+
+    if (config.setupTestFrameworkScriptFile) {
+      require(config.setupTestFrameworkScriptFile);
+    }
+
     const { CLIEngine } = getLocalESLint(config);
     const options = getESLintOptions(config);
     const cli = new CLIEngine(options.cliOptions);


### PR DESCRIPTION
Jest allows for an option called `setupTestFrameworkScriptFile` that is defined
as a path to a module that is run before each of your test files. This commit
adds similar support to jest-runner-eslint.

This implementation will only actually run the setupTestFrameworkScriptFile one
time, since this runner executes the tests in persistent workers instead of
isolated vms.

We're working on some internal tooling that we hope can server as an abstracted eslint, and we're hoping to use this tool.  We're running into some issues though as the tool assumes that eslint will be installed in our app, and we'd rather use it as a dependency of our tool.

An alternative to this approach would be to expand the configuration of this tool to allow us to point to our preferred eslint install. Let me know if that's preferable.