### PR TITLE
Use env var to override local eslint location

### DIFF
--- a/src/utils/getLocalESLint.js
+++ b/src/utils/getLocalESLint.js
@@ -2,6 +2,10 @@ const path = require('path');
 const findUp = require('find-up');
 
 const getLocalESLint = config => {
+  if (process.env.ESLINT_PATH) {
+    // eslint-disable-next-line import/no-dynamic-require,global-require
+    return require(process.env.ESLINT_PATH);
+  }
   const nodeModulesPath = findUp.sync('node_modules', { cwd: config.rootDir });
   // eslint-disable-next-line import/no-dynamic-require, global-require
   return require(path.resolve(nodeModulesPath, 'eslint'));


### PR DESCRIPTION
The rationale behind this is we have a non-standard project set up. We have a lot of .js files that are not part of a npm project, and hence don't have any /node_modules/ anywhere in the ancestor path. 

We work around this for jest transformers/resolvers by always specifying the full filesystem path to the node module, instead of just relying on the node resolution algorithm to discover modules. 

When trying to use this eslint-runner, the eslint location can not be found. This is a simple change that lets one to use the env var ESLINT_PATH to override the location of the local eslint. Had do use the env, since jest doesn't pass any options to the test runners (unfortunately). 
