### PR TITLE
fix(cli-options): rules should be passed as an object instead of array of strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,5 +193,5 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 |parser|`espree`|`"parser": "flow"`
 |parserOptions|`{}`|`"parserOptions": { "myOption": true }`
 |plugin|`[]`|`"plugin": "prettier"` or `"plugin": ["pettier", "other"]`
-|rule|`null`|`"rule": "'quotes: [2, double]'"` or `"rule": ["quotes: [2, double]", "no-console: 2"]`
+|rules|`null`|`"rules": {"quotes": [2, "double"]}` or `"rules": {"quotes": [2, "double"], "no-console": 2}`
 |rulesdir|`[]`|`"rulesdir": "/path/to/rules/dir"` or `"env": ["/path/to/rules/dir", "/path/to/other"]`

--- a/src/utils/__tests__/normalizeConfig.test.js
+++ b/src/utils/__tests__/normalizeConfig.test.js
@@ -169,17 +169,15 @@ it('normalizes rulesdir', () => {
   });
 });
 
-it('normalizes rule', () => {
+it('normalizes rules', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
     rules: null,
   });
 
-  expect(normalizeCLIOptions({ rule: ['quotes: [2, double]'] })).toMatchObject({
-    rules: ['quotes: [2, double]'],
-  });
+  const ruleOptions = { quotes: [2, 'double'], 'no-console': 2 };
 
-  expect(normalizeCLIOptions({ rule: 'quotes: [2, double]' })).toMatchObject({
-    rules: ['quotes: [2, double]'],
+  expect(normalizeCLIOptions({ rules: ruleOptions })).toMatchObject({
+    rules: ruleOptions,
   });
 });
 

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -24,7 +24,7 @@ const BASE_CONFIG = {
     default: false,
   },
   format: {
-    default: null
+    default: null,
   },
   global: {
     name: 'globals',
@@ -60,10 +60,8 @@ const BASE_CONFIG = {
     default: [],
     transform: asArray,
   },
-  rule: {
-    name: 'rules',
+  rules: {
     default: null,
-    transform: asArray,
   },
   rulesdir: {
     name: 'rulePaths',


### PR DESCRIPTION
Fixes: https://github.com/jest-community/jest-runner-eslint/issues/27#issuecomment-375263725

In the [ESLint docs for the CLIEngine](https://eslint.org/docs/developer-guide/nodejs-api#cliengine) clearly states that `rules` is a JSON object and not an array of strings.

The "string" version (e.g. `--rule "quotes: [2, double]"`) is only used by the CLI. When the args are parsed, the `rule` is also a JSON object.

In the case of this library, the `jest-runner-eslint.config.js` is a js file, so we can pass an object directly.

```js
module.exports = {
  cliOptions: {
    format: 'node_modules/eslint-formatter-pretty',
    rules: {
      'import/no-unresolved': 2,
      'prettier/prettier': [
        'error',
        { trailingComma: 'es5', singleQuote: true },
      ],
    },
  },
};
```

Now ESLint properly receives the additional rules.