### PR TITLE
fix: eslint module path resolver for yarn workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
   "dependencies": {
     "cosmiconfig": "^3.0.1",
     "eslint": "^4.5.0",
-    "find-up": "^2.1.0",
     "pify": "3.0.0",
+    "resolve": "1.7.1",
     "throat": "4.1.0",
     "worker-farm": "1.5.0"
   },

--- a/src/utils/__tests__/getLocalESLint.test.js
+++ b/src/utils/__tests__/getLocalESLint.test.js
@@ -1,0 +1,12 @@
+const getLocalESLint = require('../getLocalESLint');
+const requiredESLint = require('eslint');
+
+it('requires eslint', () => {
+  // eslint-disable-next-line global-require
+  expect(getLocalESLint({})).toBe(requiredESLint);
+});
+
+it('finds eslint with custom rootDir', () => {
+  // eslint-disable-next-line global-require
+  expect(getLocalESLint({ rootDir: __dirname })).toBe(requiredESLint);
+});

--- a/src/utils/getLocalESLint.js
+++ b/src/utils/getLocalESLint.js
@@ -1,10 +1,10 @@
-const path = require('path');
-const findUp = require('find-up');
+const resolve = require('resolve');
 
 const getLocalESLint = config => {
-  const nodeModulesPath = findUp.sync('node_modules', { cwd: config.rootDir });
+  const basedir = config.rootDir || process.cwd();
+  const eslintModulePath = resolve.sync('eslint', { basedir });
   // eslint-disable-next-line import/no-dynamic-require, global-require
-  return require(path.resolve(nodeModulesPath, 'eslint'));
+  return require(eslintModulePath);
 };
 
 module.exports = getLocalESLint;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2825,6 +2825,12 @@ resolve@1.1.7:
   version "1.1.7"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
 
+resolve@1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.7.1.tgz#aadd656374fd298aee895bc026b8297418677fd3"
+  dependencies:
+    path-parse "^1.0.5"
+
 resolve@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.4.0.tgz#a75be01c53da25d934a98ebd0e4c4a7312f92a86"


### PR DESCRIPTION
Instead of looking for the closest node_modules, it will resolve the path like require.resolve() starting from config.rootDir.

Fixes #41
All tests pass
Rejoice