### PR TITLE
Add more options

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 |global|`[]`|`"global": "it"` or `"global": ["it", "describe"]`
 |ignorePath|`null`|`"ignorePath": "/path/to/ignore"`
 |ignorePattern|`[]`|`"ignorePattern": ["/path/to/ignore/*"]`
+|maxWarnings|`-1`|`"maxWarnings": 0`
 |noEslintrc|`false`|`"noEslintrc": true`
 |noIgnore|`false`|`"noIgnore": true`
 |noInlineConfig|`false`|`"noInlineConfig": true`

--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 |parser|`espree`|`"parser": "flow"`
 |parserOptions|`{}`|`"parserOptions": { "myOption": true }`
 |plugin|`[]`|`"plugin": "prettier"` or `"plugin": ["pettier", "other"]`
+|quiet|`true`|`"quiet": false`
 |reportUnusedDisableDirectives|`false`|`"reportUnusedDisableDirectives": true`
 |rules|`null`|`"rules": {"quotes": [2, "double"]}` or `"rules": {"quotes": [2, "double"], "no-console": 2}`
 |rulesdir|`[]`|`"rulesdir": "/path/to/rules/dir"` or `"env": ["/path/to/rules/dir", "/path/to/other"]`

--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 |env|`null`|`"env": "mocha"` or `"env": ["mocha", "other"]`
 |ext|`[".js"]`|`"ext": ".jsx"` or `"ext": [".jsx", ".ts"]`
 |fix|`false`|`"fix": true`
+|fixDryRun|`false`|`"fixDryRun": true`
 |format|`null`|`"format": "codeframe"`
 |global|`[]`|`"global": "it"` or `"global": ["it", "describe"]`
 |ignorePath|`null`|`"ignorePath": "/path/to/ignore"`

--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 
 |option|default|example
 |-----|-----|-----|
+|cache|`false`|`"cache": true`
 |cacheLocation|`.eslintcache`|`"cacheLocation": "/path/to/cache"`
 |config|`null`|`"config": "/path/to/config"`
 |env|`null`|`"env": "mocha"` or `"env": ["mocha", "other"]`
@@ -187,11 +188,13 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 |format|`null`|`"format": "codeframe"`
 |global|`[]`|`"global": "it"` or `"global": ["it", "describe"]`
 |ignorePath|`null`|`"ignorePath": "/path/to/ignore"`
+|ignorePattern|`[]`|`"ignorePattern": ["/path/to/ignore/*"]`
 |noEslintrc|`false`|`"noEslintrc": true`
 |noIgnore|`false`|`"noIgnore": true`
 |noInlineConfig|`false`|`"noInlineConfig": true`
 |parser|`espree`|`"parser": "flow"`
 |parserOptions|`{}`|`"parserOptions": { "myOption": true }`
 |plugin|`[]`|`"plugin": "prettier"` or `"plugin": ["pettier", "other"]`
+|reportUnusedDisableDirectives|`false`|`"reportUnusedDisableDirectives": true`
 |rules|`null`|`"rules": {"quotes": [2, "double"]}` or `"rules": {"quotes": [2, "double"], "no-console": 2}`
 |rulesdir|`[]`|`"rulesdir": "/path/to/rules/dir"` or `"env": ["/path/to/rules/dir", "/path/to/other"]`

--- a/integrationTests/__fixtures__/loud/.eslintrc.json
+++ b/integrationTests/__fixtures__/loud/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "warn"
+  }
+}

--- a/integrationTests/__fixtures__/loud/__eslint__/file.js
+++ b/integrationTests/__fixtures__/loud/__eslint__/file.js
@@ -1,0 +1,3 @@
+const a = 1;
+
+console.log('a', a);

--- a/integrationTests/__fixtures__/loud/jest-runner-eslint.config.js
+++ b/integrationTests/__fixtures__/loud/jest-runner-eslint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cliOptions: {
+    quiet: false,
+  },
+};

--- a/integrationTests/__fixtures__/loud/jest.config.js
+++ b/integrationTests/__fixtures__/loud/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  runner: '../../../',
+  testMatch: ['**/__eslint__/**/*.js'],
+};

--- a/integrationTests/__fixtures__/max-warnings/.eslintrc.json
+++ b/integrationTests/__fixtures__/max-warnings/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "warn"
+  }
+}

--- a/integrationTests/__fixtures__/max-warnings/__eslint__/file.js
+++ b/integrationTests/__fixtures__/max-warnings/__eslint__/file.js
@@ -2,3 +2,4 @@ const a = 1;
 
 console.log('a', a);
 console.log('a', a);
+console.log('a', a);

--- a/integrationTests/__fixtures__/max-warnings/__eslint__/file.js
+++ b/integrationTests/__fixtures__/max-warnings/__eslint__/file.js
@@ -1,0 +1,4 @@
+const a = 1;
+
+console.log('a', a);
+console.log('a', a);

--- a/integrationTests/__fixtures__/max-warnings/__eslint__/file2.js
+++ b/integrationTests/__fixtures__/max-warnings/__eslint__/file2.js
@@ -1,5 +1,0 @@
-const a = 1;
-
-console.log('a', a);
-console.log('a', a);
-console.log('a', a);

--- a/integrationTests/__fixtures__/max-warnings/__eslint__/file2.js
+++ b/integrationTests/__fixtures__/max-warnings/__eslint__/file2.js
@@ -1,0 +1,5 @@
+const a = 1;
+
+console.log('a', a);
+console.log('a', a);
+console.log('a', a);

--- a/integrationTests/__fixtures__/max-warnings/jest-runner-eslint.config.js
+++ b/integrationTests/__fixtures__/max-warnings/jest-runner-eslint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cliOptions: {
+    maxWarnings: 2,
+  },
+};

--- a/integrationTests/__fixtures__/max-warnings/jest.config.js
+++ b/integrationTests/__fixtures__/max-warnings/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  runner: '../../../',
+  testMatch: ['**/__eslint__/**/*.js'],
+};

--- a/integrationTests/__snapshots__/loud.test.js.snap
+++ b/integrationTests/__snapshots__/loud.test.js.snap
@@ -1,0 +1,17 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Outputs warnings as console messages 1`] = `
+"PASS integrationTests/__fixtures__/loud/__eslint__/file.js
+  ● Console
+  console.warn
+    /mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/loud/__eslint__/file.js
+      3:1  warning  Unexpected console statement  no-console
+    ✖ 1 problem (0 errors, 1 warning)
+  ✓ ESLint
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:
+Ran all test suites.
+"
+`;

--- a/integrationTests/__snapshots__/max-warnings.test.js.snap
+++ b/integrationTests/__snapshots__/max-warnings.test.js.snap
@@ -1,11 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Fails if more than max warnings 1`] = `
-"PASS integrationTests/__fixtures__/max-warnings/__eslint__/file.js
-FAIL integrationTests/__fixtures__/max-warnings/__eslint__/file2.js
+"FAIL integrationTests/__fixtures__/max-warnings/__eslint__/file.js
+/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/max-warnings/__eslint__/file.js
+  3:1  warning  Unexpected console statement  no-console
+  4:1  warning  Unexpected console statement  no-console
+  5:1  warning  Unexpected console statement  no-console
+✖ 3 problems (0 errors, 3 warnings)
 ESLint found too many warnings (maximum: 2).
-Test Suites: 1 failed, 1 passed, 2 total
-Tests:       1 failed, 1 passed, 2 total
+  ✕ ESLint
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
 Snapshots:   0 total
 Time:
 Ran all test suites.

--- a/integrationTests/__snapshots__/max-warnings.test.js.snap
+++ b/integrationTests/__snapshots__/max-warnings.test.js.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Fails if more than max warnings 1`] = `
+"PASS integrationTests/__fixtures__/max-warnings/__eslint__/file.js
+FAIL integrationTests/__fixtures__/max-warnings/__eslint__/file2.js
+ESLint found too many warnings (maximum: 2).
+Test Suites: 1 failed, 1 passed, 2 total
+Tests:       1 failed, 1 passed, 2 total
+Snapshots:   0 total
+Time:
+Ran all test suites.
+
+"
+`;

--- a/integrationTests/loud.test.js
+++ b/integrationTests/loud.test.js
@@ -1,0 +1,5 @@
+const runJest = require('./runJest');
+
+it('Outputs warnings as console messages', () => {
+  return expect(runJest('loud')).resolves.toMatchSnapshot();
+});

--- a/integrationTests/max-warnings.test.js
+++ b/integrationTests/max-warnings.test.js
@@ -1,0 +1,5 @@
+const runJest = require('./runJest');
+
+it('Fails if more than max warnings', () => {
+  return expect(runJest('max-warnings')).resolves.toMatchSnapshot();
+});

--- a/src/runESLint.js
+++ b/src/runESLint.js
@@ -12,7 +12,7 @@ const runESLint = ({ testPath, config }) => {
 
   const { CLIEngine } = getLocalESLint(config);
   const options = getESLintOptions(config);
-  const quiet = !options.cliOptions || options.cliOptions.quiet !== false;
+  const quiet = options.cliOptions && options.cliOptions.quiet;
   const cli = new CLIEngine(
     Object.assign({}, options.cliOptions, {
       fix:

--- a/src/runESLint.js
+++ b/src/runESLint.js
@@ -12,7 +12,13 @@ const runESLint = ({ testPath, config }) => {
 
   const { CLIEngine } = getLocalESLint(config);
   const options = getESLintOptions(config);
-  const cli = new CLIEngine(options.cliOptions);
+  const cli = new CLIEngine(
+    Object.assign({}, options.cliOptions, {
+      fix:
+        options.cliOptions &&
+        (options.cliOptions.fix || options.cliOptions.fixDryRun),
+    }),
+  );
   if (cli.isPathIgnored(testPath)) {
     const end = Date.now();
     return skip({ start, end, test: { path: testPath, title: 'ESLint' } });
@@ -20,7 +26,11 @@ const runESLint = ({ testPath, config }) => {
 
   const report = cli.executeOnFiles([testPath]);
 
-  if (options.cliOptions && options.cliOptions.fix) {
+  if (
+    options.cliOptions &&
+    options.cliOptions.fix &&
+    !options.cliOptions.fixDryRun
+  ) {
     CLIEngine.outputFixes(report);
   }
 

--- a/src/runESLint.js
+++ b/src/runESLint.js
@@ -12,11 +12,13 @@ const runESLint = ({ testPath, config }) => {
 
   const { CLIEngine } = getLocalESLint(config);
   const options = getESLintOptions(config);
+  const quiet = !options.cliOptions || options.cliOptions.quiet !== false;
   const cli = new CLIEngine(
     Object.assign({}, options.cliOptions, {
       fix:
         options.cliOptions &&
-        (options.cliOptions.fix || options.cliOptions.fixDryRun),
+        (options.cliOptions.fix || options.cliOptions.fixDryRun) &&
+        (quiet ? ({ severity }) => severity === 2 : true),
     }),
   );
   if (cli.isPathIgnored(testPath)) {
@@ -42,9 +44,15 @@ const runESLint = ({ testPath, config }) => {
     options.cliOptions.maxWarnings >= 0 &&
     report.warningCount > options.cliOptions.maxWarnings;
 
-  if (report.errorCount > 0 || tooManyWarnings) {
+  const format = () => {
     const formatter = cli.getFormatter(options.cliOptions.format);
-    let errorMessage = formatter(CLIEngine.getErrorResults(report.results));
+    return formatter(
+      quiet ? CLIEngine.getErrorResults(report.results) : report.results,
+    );
+  };
+
+  if (report.errorCount > 0 || tooManyWarnings) {
+    let errorMessage = format();
 
     if (!report.errorCount && tooManyWarnings)
       errorMessage += `\nESLint found too many warnings (maximum: ${options
@@ -57,7 +65,17 @@ const runESLint = ({ testPath, config }) => {
     });
   }
 
-  return pass({ start, end, test: { path: testPath, title: 'ESLint' } });
+  const result = pass({
+    start,
+    end,
+    test: { path: testPath, title: 'ESLint' },
+  });
+
+  if (!quiet && report.warningCount > 0) {
+    result.console = [{ message: format(), origin: '', type: 'warn' }];
+  }
+
+  return result;
 };
 
 module.exports = runESLint;

--- a/src/runESLint.js
+++ b/src/runESLint.js
@@ -36,9 +36,19 @@ const runESLint = ({ testPath, config }) => {
 
   const end = Date.now();
 
-  if (report.errorCount > 0) {
+  const tooManyWarnings =
+    options.cliOptions &&
+    options.cliOptions.maxWarnings != null &&
+    options.cliOptions.maxWarnings >= 0 &&
+    report.warningCount > options.cliOptions.maxWarnings;
+
+  if (report.errorCount > 0 || tooManyWarnings) {
     const formatter = cli.getFormatter(options.cliOptions.format);
-    const errorMessage = formatter(CLIEngine.getErrorResults(report.results));
+    let errorMessage = formatter(CLIEngine.getErrorResults(report.results));
+
+    if (!report.errorCount && tooManyWarnings)
+      errorMessage += `\nESLint found too many warnings (maximum: ${options
+        .cliOptions.maxWarnings}).`;
 
     return fail({
       start,

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -76,7 +76,7 @@ const BASE_CONFIG = {
     transform: asArray,
   },
   quiet: {
-    default: true,
+    default: false,
   },
   reportUnusedDisableDirectives: {
     default: false,

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -26,6 +26,9 @@ const BASE_CONFIG = {
   fix: {
     default: false,
   },
+  fixDryRun: {
+    default: false,
+  },
   format: {
     default: null,
   },

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -75,6 +75,9 @@ const BASE_CONFIG = {
     default: [],
     transform: asArray,
   },
+  quiet: {
+    default: true,
+  },
   reportUnusedDisableDirectives: {
     default: false,
   },

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -1,6 +1,7 @@
 const identity = v => v;
 const negate = v => !v;
 const asArray = v => (typeof v === 'string' ? [v] : v);
+const asInt = v => (typeof v === 'number' ? v : parseInt(v, 10));
 
 const BASE_CONFIG = {
   cache: {
@@ -43,6 +44,10 @@ const BASE_CONFIG = {
   ignorePattern: {
     default: [],
     transform: asArray,
+  },
+  maxWarnings: {
+    default: -1,
+    transform: asInt,
   },
   noEslintrc: {
     name: 'useEslintrc',

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -3,6 +3,9 @@ const negate = v => !v;
 const asArray = v => (typeof v === 'string' ? [v] : v);
 
 const BASE_CONFIG = {
+  cache: {
+    default: false,
+  },
   cacheLocation: {
     default: '.eslintcache',
   },
@@ -34,6 +37,10 @@ const BASE_CONFIG = {
   ignorePath: {
     default: null,
   },
+  ignorePattern: {
+    default: [],
+    transform: asArray,
+  },
   noEslintrc: {
     name: 'useEslintrc',
     default: false,
@@ -59,6 +66,9 @@ const BASE_CONFIG = {
     name: 'plugins',
     default: [],
     transform: asArray,
+  },
+  reportUnusedDisableDirectives: {
+    default: false,
   },
   rules: {
     default: null,


### PR DESCRIPTION
This PR adds the remaining options that makes sense. I made `quiet` default to `true` so it doesn't impact the current behavior. If `false`, any warnings are output as `console.warn` messages in the test result log. The `maxWarnings` option is a little weird, since files are linted individually, whereas the actual cli option applies to warnings across all files. My use case is `maxWarnings: 0`, and that's all that I've ever seen in the wild, so I'm not sure it's that big of a deal.