### PR TITLE
fix: parserOptions, rules default values for ESLint 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,5 +220,5 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 | plugin                        | `[]`           | `"plugin": "prettier"` or `"plugin": ["pettier", "other"]`                                    |
 | quiet                         | `true`         | `"quiet": false`                                                                              |
 | reportUnusedDisableDirectives | `false`        | `"reportUnusedDisableDirectives": true`                                                       |
-| rules                         | `null`         | `"rules": {"quotes": [2, "double"]}` or `"rules": {"quotes": [2, "double"], "no-console": 2}` |
+| rules                         | `{}`           | `"rules": {"quotes": [2, "double"]}` or `"rules": {"quotes": [2, "double"], "no-console": 2}` |
 | rulesdir                      | `[]`           | `"rulesdir": "/path/to/rules/dir"` or `"env": ["/path/to/rules/dir", "/path/to/other"]`       |

--- a/src/utils/__tests__/normalizeConfig.test.js
+++ b/src/utils/__tests__/normalizeConfig.test.js
@@ -142,7 +142,9 @@ it('normalizes parser', () => {
 });
 
 it('normalizes parserOptions', () => {
-  expect(normalizeCLIOptions({}).parseOptions).toBeUndefined();
+  expect(normalizeCLIOptions({})).toMatchObject({
+    parserOptions: {},
+  });
 
   expect(
     normalizeCLIOptions({ parserOptions: { ecmaVersion: 2015 } }),
@@ -183,7 +185,7 @@ it('normalizes rulesdir', () => {
 
 it('normalizes rules', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
-    rules: null,
+    rules: {},
   });
 
   const ruleOptions = { quotes: [2, 'double'], 'no-console': 2 };

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -77,7 +77,7 @@ const BASE_CONFIG = {
     default: null,
   },
   parserOptions: {
-    default: null,
+    default: {},
   },
   plugin: {
     name: 'plugins',
@@ -91,7 +91,7 @@ const BASE_CONFIG = {
     default: false,
   },
   rules: {
-    default: null,
+    default: {},
   },
   rulesdir: {
     name: 'rulePaths',


### PR DESCRIPTION
# Problem
When trying to use `jest-runner-eslint` on a project being upgraded to ESLint 6 there are the following errors:
```
ESLint configuration in CLIOptions is invalid:
    - Property "parserOptions" is the wrong type (expected object but got `null`).
    - Property "rules" is the wrong type (expected object but got `null`).
```

### Setup
I "use ESLint 6" by forcing the version using the following in my `package.json`
```json
  "resolutions": { "eslint": "6.4.0" },
```


# Cause
ESLint 6 introduces type checks on the config.
See ~ **PR:** https://github.com/eslint/eslint/pull/11546 || **Commit:** https://github.com/eslint/eslint/commit/6ae21a4bfe5a1566f787fbad798182a524b96d28

Two default values set in `normalizeConfig.js` are not compatible.

- `config.parserOptions` is typed as an `object` so `null` is not valid.
https://github.com/eslint/eslint/blob/2e202ca2228846e6226aa8dd99c614d572fb86a8/lib/shared/types.js#L22

- `config.rules` is typed as a `Record` so `null` is not valid.
https://github.com/eslint/eslint/blob/2e202ca2228846e6226aa8dd99c614d572fb86a8/lib/shared/types.js#L41

# Fix

Change the default values for these two configurations from `null` to `{}` in `normalizeConfig.js`.

Using this change `jest-runner-eslint` + ESlint 6 runs normally for my project. I also tested with this change but back on ESLint 5 and that continues to work.

This is not intended to fully support ESLint 6 but step in the right direction.