### PR TITLE
chore: docs - correct default value for ‘quiet’

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 | parser                        | `espree`       | `"parser": "flow"`                                                                            |
 | parserOptions                 | `{}`           | `"parserOptions": { "myOption": true }`                                                       |
 | plugin                        | `[]`           | `"plugin": "prettier"` or `"plugin": ["pettier", "other"]`                                    |
-| quiet                         | `true`         | `"quiet": false`                                                                              |
+| quiet                         | `false`        | `"quiet": true`                                                                              |
 | reportUnusedDisableDirectives | `false`        | `"reportUnusedDisableDirectives": true`                                                       |
 | rules                         | `{}`           | `"rules": {"quotes": [2, "double"]}` or `"rules": {"quotes": [2, "double"], "no-console": 2}` |
 | rulesdir                      | `[]`           | `"rulesdir": "/path/to/rules/dir"` or `"env": ["/path/to/rules/dir", "/path/to/other"]`       |


### PR DESCRIPTION
Fixing this default value in the docs which doesn't match what it is in normalizeConfig.js