### PR TITLE
feat(cli-options): support resolvePluginsRelativeTo

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,8 @@ jest-runner-eslint maps a lot of ESLint CLI arguments to config options. For exa
 | parser                        | `espree`       | `"parser": "flow"`                                                                            |
 | parserOptions                 | `{}`           | `"parserOptions": { "myOption": true }`                                                       |
 | plugin                        | `[]`           | `"plugin": "prettier"` or `"plugin": ["pettier", "other"]`                                    |
-| quiet                         | `false`        | `"quiet": true`                                                                              |
+| quiet                         | `false`        | `"quiet": true`                                                                               |
+| resolvePluginsRelativeTo      | `undefined`    | `"resolvePluginsRelativeTo": "./eslint-config"`                                               |
 | reportUnusedDisableDirectives | `false`        | `"reportUnusedDisableDirectives": true`                                                       |
 | rules                         | `{}`           | `"rules": {"quotes": [2, "double"]}` or `"rules": {"quotes": [2, "double"], "no-console": 2}` |
 | rulesdir                      | `[]`           | `"rulesdir": "/path/to/rules/dir"` or `"env": ["/path/to/rules/dir", "/path/to/other"]`       |

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -90,6 +90,9 @@ const BASE_CONFIG = {
   reportUnusedDisableDirectives: {
     default: false,
   },
+  resolvePluginsRelativeTo: {
+    default: undefined,
+  },
   rules: {
     default: {},
   },


### PR DESCRIPTION
Closes #94.

I did not add a test case to `normalizeConfig.test.js` as it already doesn't have test cases for every option, only for every option type to make sure the type conversions work. This is pretty declarative anyway so declaring the new option again in the test would just be repitition.
Manually tested by linking into a project that does not work without setting the option - it works now.

Could consider passing the cwd to ESLint ourselves as a default instead of relying on the ESLint default by passing `undefined` as a default. This is the first option to pass `undefined` by default. But I don't see a reason why `jest-runner-eslint` would need to take control of the default option here.