### PR TITLE
chore: detect version of eslint, not its engine

### DIFF
--- a/integrationTests/custom-parser.test.js
+++ b/integrationTests/custom-parser.test.js
@@ -1,14 +1,14 @@
-const eslint = require('eslint');
+const { version } = require('eslint/package.json');
+const semver = require('semver');
 const runJest = require('./runJest');
+
+const isBelow6 = semver.satisfies(version, '<6');
 
 // Note: ESLint versions <6 have a different error message for this test. The
 // snapshot file contains both messages so we can test across both versions.
 // Without the skipped tests for the "other" version, the tests will always fail
 // with `1 snapshot obsolete`.
-if (
-  eslint.CLIEngine.version.startsWith('4') ||
-  eslint.CLIEngine.version.startsWith('5')
-) {
+if (isBelow6) {
   it.skip("Doesn't override parser when not set", () => {});
   it("Doesn't override parser when not set [ESLint<6]", async () => {
     expect(await runJest('custom-parser')).toMatchSnapshot();


### PR DESCRIPTION
`CLIEngine` export is deprecated in v7 and removed in v8 of ESLint, so let's look at the ESLint package version instead.