### PR TITLE
Catch ESLint lintFiles errors (fixes #96)

### DIFF
--- a/integrationTests/__fixtures__/rule-error/.eslintrc.js
+++ b/integrationTests/__fixtures__/rule-error/.eslintrc.js
@@ -1,0 +1,12 @@
+const path = require('path');
+const rulesDirPlugin = require('eslint-plugin-rulesdir');
+
+rulesDirPlugin.RULES_DIR  = path.join(__dirname, 'rules');
+
+module.exports = {
+  plugins: ['rulesdir'],
+  rules: {
+    quotes: ['error', 'double'],
+    'rulesdir/intentional-error': ['error'],
+  }
+}

--- a/integrationTests/__fixtures__/rule-error/__eslint__/one.js
+++ b/integrationTests/__fixtures__/rule-error/__eslint__/one.js
@@ -1,0 +1,1 @@
+console.log('one');

--- a/integrationTests/__fixtures__/rule-error/__eslint__/two.js
+++ b/integrationTests/__fixtures__/rule-error/__eslint__/two.js
@@ -1,0 +1,1 @@
+console.log('two');

--- a/integrationTests/__fixtures__/rule-error/jest.config.js
+++ b/integrationTests/__fixtures__/rule-error/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  runner: '../../../',
+  testMatch: ['**/__eslint__/**/*.js'],
+};

--- a/integrationTests/__fixtures__/rule-error/rules/intentional-error.js
+++ b/integrationTests/__fixtures__/rule-error/rules/intentional-error.js
@@ -1,0 +1,17 @@
+// Intentional create an error from eslint
+module.exports = {
+  meta: {
+    docs: {
+      description: 'Cause an intentional error at rule evalutation time',
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      Identifier(node) {
+        const obj = {};
+        obj.will.cause.an.error.here;
+      }
+    }
+  }
+};

--- a/integrationTests/__snapshots__/rule-error.test.js.snap
+++ b/integrationTests/__snapshots__/rule-error.test.js.snap
@@ -1,0 +1,16 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Correctly prints the error message from a failing ESLint rule 1`] = `
+"FAIL integrationTests/__fixtures__/rule-error/__eslint__/one.js
+Cannot read property 'cause' of undefined
+Occurred while linting /mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/rule-error/__eslint__/one.js:1
+FAIL integrationTests/__fixtures__/rule-error/__eslint__/two.js
+Cannot read property 'cause' of undefined
+Occurred while linting /mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/rule-error/__eslint__/two.js:1
+Test Suites: 2 failed, 2 total
+Tests:       2 failed, 2 total
+Snapshots:   0 total
+Time:
+Ran all test suites.
+"
+`;

--- a/integrationTests/rule-error.test.js
+++ b/integrationTests/rule-error.test.js
@@ -1,0 +1,5 @@
+const runJest = require('./runJest');
+
+it('Correctly prints the error message from a failing ESLint rule', async () => {
+  expect(await runJest('rule-error')).toMatchSnapshot();
+});

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-jest": "^23.17.1",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-rulesdir": "^0.2.1",
     "execa": "^3.4.0",
     "jest": "^25.1 || ^26 || ^27 || ^28",
     "jest-watch-select-projects": "^2.0.0",

--- a/src/runner/runESLint.js
+++ b/src/runner/runESLint.js
@@ -84,7 +84,20 @@ const runESLint = async ({ testPath, config, extraOptions }) => {
     return skip({ start, end, test: { path: testPath, title: 'ESLint' } });
   }
 
-  const report = await lintFiles([testPath]);
+  let report;
+  try {
+    report = await lintFiles([testPath]);
+  } catch (e) {
+    return fail({
+      start,
+      end: Date.now(),
+      test: {
+        path: testPath,
+        title: 'ESLint execution error',
+        errorMessage: e.message,
+      }
+    });
+  }
 
   if (cliOptions.fix && !cliOptions.fixDryRun) {
     await ESLintEngine.outputFixes(report);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2281,6 +2281,11 @@ eslint-plugin-prettier@^3.1.4:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-rulesdir@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-rulesdir/-/eslint-plugin-rulesdir-0.2.1.tgz#e246bb9657e68eb0a30680c60775f40aa829ec0b"
+  integrity sha512-t7rQvEyfE4JZJu6dPl4/uVr6Fr0fxopBhzVbtq3isfOHMKdlIe9xW/5CtIaWZI0E1U+wzAk0lEnZC8laCD5YLA==
+
 eslint-scope@^5.0.0, eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"


### PR DESCRIPTION
Hello!

Right now, if an ESLint rule throws an error, the error object includes a reference to the AST node where the error originated, which includes circular data structures. `jest-runner-eslint` doesn't do anything special for these errors.

If the tests are running in band, this is not an issue: Jest correctly shows the error to the user. However, if the test is running in a child process, the runner tries to send the circular data structure back to the main process, which produces the `Converting circular structure to JSON` error shown in #96.

This patch puts a `try…catch` around the call to `lintFiles`, so the error message can be reported to Jest explicitly, preventing the circular reference from being propagated.