### PR TITLE
Support eslint's new flat config

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x, 18.x, 19.x]
-        eslint-version: [7, 8]
+        eslint-version: [7, "8.40", 8]
         jest-version: [27, 28, 29]
         jest-watch-typeahead-version: [1, 2]
         exclude:

--- a/integrationTests/__fixtures__/flat-config/__eslint__/file.js
+++ b/integrationTests/__fixtures__/flat-config/__eslint__/file.js
@@ -1,0 +1,3 @@
+const a = 1;
+
+console.log('a', a);

--- a/integrationTests/__fixtures__/flat-config/eslint.config.js
+++ b/integrationTests/__fixtures__/flat-config/eslint.config.js
@@ -1,0 +1,7 @@
+module.exports = [
+  {
+    rules: {
+      'no-console': 'error',
+    },
+  },
+];

--- a/integrationTests/__fixtures__/flat-config/jest.config.js
+++ b/integrationTests/__fixtures__/flat-config/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  runner: '../../../',
+  testMatch: ['**/__eslint__/**/*.js'],
+};

--- a/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/__eslint__/file.js
+++ b/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/__eslint__/file.js
@@ -1,0 +1,3 @@
+const a = 1;
+
+console.log('a', a);

--- a/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/eslint.config.js
+++ b/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/eslint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  rules: {
+    'no-console': 'error',
+  },
+};

--- a/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/jest-runner-eslint.config.js
+++ b/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/jest-runner-eslint.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  config: './eslint.config.js',
+};

--- a/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/jest.config.js
+++ b/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  runner: '../../../',
+  testMatch: ['**/__eslint__/**/*.js'],
+};

--- a/integrationTests/__snapshots__/flat-config.test.js.snap
+++ b/integrationTests/__snapshots__/flat-config.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Works with the new flat config format 1`] = `
+"FAIL __eslint__/file.js
+  ✕ no-console 
+
+
+/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/flat-config/__eslint__/file.js
+  3:1  error  Unexpected console statement  no-console
+
+✖ 1 problem (1 error, 0 warnings)
+
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        
+Ran all test suites.
+"
+`;

--- a/integrationTests/__snapshots__/legacy-config-at-eslint.config.js.test.js.snap
+++ b/integrationTests/__snapshots__/legacy-config-at-eslint.config.js.test.js.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Does not try to use flat config on eslint versions that don't support it 1`] = `
+"PASS __eslint__/file.js
+  ● Console
+
+  console.warn
+    
+    /mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/legacy-config-at-eslint.config.js/__eslint__/file.js
+      3:1  warning  Unexpected console statement  no-console
+    
+    ✖ 1 problem (0 errors, 1 warning)
+
+  ✓ ESLint 
+
+Test Suites: 1 passed, 1 total
+Tests:       1 passed, 1 total
+Snapshots:   0 total
+Time:        
+Ran all test suites.
+"
+`;

--- a/integrationTests/flat-config.test.js
+++ b/integrationTests/flat-config.test.js
@@ -1,0 +1,10 @@
+const { version } = require('eslint/package.json');
+const semver = require('semver');
+const runJest = require('./runJest');
+
+(semver.satisfies(version, '>=8.41') ? it : it.skip)(
+  'Works with the new flat config format',
+  async () => {
+    expect(await runJest('flat-config')).toMatchSnapshot();
+  },
+);

--- a/integrationTests/legacy-config-at-eslint.config.js.test.js
+++ b/integrationTests/legacy-config-at-eslint.config.js.test.js
@@ -1,0 +1,12 @@
+const { version } = require('eslint/package.json');
+const semver = require('semver');
+const runJest = require('./runJest');
+
+(semver.satisfies(version, '<8.41') ? it : it.skip)(
+  "Does not try to use flat config on eslint versions that don't support it",
+  async () => {
+    expect(
+      await runJest('legacy-config-at-eslint.config.js'),
+    ).toMatchSnapshot();
+  },
+);


### PR DESCRIPTION
Fixes #166 .

Note I also had to change the strategy for running integration tests is this PR.  Prior to this PR, integration tests ran in a child process where the cwd was the root of the integration tests, and jest projects were used to select individual integration test directories.  However, [eslint will look for the flat config starting in the process cwd](https://github.com/eslint/eslint/blob/d85efad655deacc0dc3fdbbace33307094c3b91b/lib/cli.js#L299), so with that strategy the flat config would have to be placed in a common path to all integration tests, and thus the integration test runs would always detect that they're running in flat config mode.

As of this PR, the integration tests run with a child process where the cwd is the individual integration test fixture path as well.  Practically, this required updating some snapshots and moving some `.eslintignore` entries into the test fixture folders.