### PR TITLE
Remove cliengine code

### DIFF
--- a/src/utils/__tests__/normalizeConfig.test.js
+++ b/src/utils/__tests__/normalizeConfig.test.js
@@ -37,25 +37,31 @@ it('normalizes cacheLocation', () => {
 
 it('normalizes config', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
-    configFile: null,
+    overrideConfigFile: null,
   });
 
   expect(normalizeCLIOptions({ config: '/path/to/config' })).toMatchObject({
-    configFile: '/path/to/config',
+    overrideConfigFile: '/path/to/config',
   });
 });
 
 it('normalizes env', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
-    envs: [],
+    overrideConfig: {
+      env: {},
+    },
   });
 
   expect(normalizeCLIOptions({ env: 'mocha' })).toMatchObject({
-    envs: ['mocha'],
+    overrideConfig: {
+      env: 'mocha',
+    },
   });
 
   expect(normalizeCLIOptions({ env: ['mocha', 'browser'] })).toMatchObject({
-    envs: ['mocha', 'browser'],
+    overrideConfig: {
+      env: ['mocha', 'browser'],
+    },
   });
 });
 
@@ -85,15 +91,21 @@ it('normalizes fix', () => {
 
 it('normalizes global', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
-    globals: [],
+    overrideConfig: {
+      globals: {},
+    },
   });
 
   expect(normalizeCLIOptions({ global: 'it' })).toMatchObject({
-    globals: ['it'],
+    overrideConfig: {
+      globals: 'it',
+    },
   });
 
   expect(normalizeCLIOptions({ global: ['it', 'describe'] })).toMatchObject({
-    globals: ['it', 'describe'],
+    overrideConfig: {
+      globals: ['it', 'describe'],
+    },
   });
 });
 
@@ -133,37 +145,51 @@ it('normalizes ignorePath', () => {
 
 it('normalizes parser', () => {
   expect(normalizeCLIOptions({})).not.toMatchObject({
-    parser: 'espree',
+    overrideConfig: {
+      parser: 'espree',
+    },
   });
 
   expect(normalizeCLIOptions({ parser: 'flow' })).toMatchObject({
-    parser: 'flow',
+    overrideConfig: {
+      parser: 'flow',
+    },
   });
 });
 
 it('normalizes parserOptions', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
-    parserOptions: {},
+    overrideConfig: {
+      parserOptions: {},
+    },
   });
 
   expect(
     normalizeCLIOptions({ parserOptions: { ecmaVersion: 2015 } }),
   ).toMatchObject({
-    parserOptions: { ecmaVersion: 2015 },
+    overrideConfig: {
+      parserOptions: { ecmaVersion: 2015 },
+    },
   });
 });
 
 it('normalizes plugin', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
-    plugins: [],
+    overrideConfig: {
+      plugins: [],
+    },
   });
 
   expect(normalizeCLIOptions({ plugin: 'prettier' })).toMatchObject({
-    plugins: ['prettier'],
+    overrideConfig: {
+      plugins: ['prettier'],
+    },
   });
 
   expect(normalizeCLIOptions({ plugin: ['prettier'] })).toMatchObject({
-    plugins: ['prettier'],
+    overrideConfig: {
+      plugins: ['prettier'],
+    },
   });
 });
 
@@ -185,13 +211,17 @@ it('normalizes rulesdir', () => {
 
 it('normalizes rules', () => {
   expect(normalizeCLIOptions({})).toMatchObject({
-    rules: {},
+    overrideConfig: {
+      rules: {},
+    },
   });
 
   const ruleOptions = { quotes: [2, 'double'], 'no-console': 2 };
 
   expect(normalizeCLIOptions({ rules: ruleOptions })).toMatchObject({
-    rules: ruleOptions,
+    overrideConfig: {
+      rules: ruleOptions,
+    },
   });
 });
 

--- a/src/utils/getESLintOptions.js
+++ b/src/utils/getESLintOptions.js
@@ -3,14 +3,14 @@ const normalizeConfig = require('./normalizeConfig');
 
 const explorer = cosmiconfigSync('jest-runner-eslint');
 
-const getESLintOptions = (config, newApi) => {
+const getESLintOptions = config => {
   const result = explorer.search(config.rootDir);
 
   if (result) {
-    return normalizeConfig(result.config, newApi);
+    return normalizeConfig(result.config);
   }
 
-  return normalizeConfig({}, newApi);
+  return normalizeConfig({});
 };
 
 module.exports = getESLintOptions;

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -14,21 +14,12 @@ const asInt = v => {
   return int;
 };
 
-const OLD_BASE_CONFIG = {
+const BASE_CONFIG = {
   cache: {
     default: false,
   },
   cacheLocation: {
     default: '.eslintcache',
-  },
-  config: {
-    name: 'configFile',
-    default: null,
-  },
-  env: {
-    name: 'envs',
-    default: [],
-    transform: asArray,
   },
   ext: {
     name: 'extensions',
@@ -44,17 +35,8 @@ const OLD_BASE_CONFIG = {
   format: {
     default: undefined,
   },
-  global: {
-    name: 'globals',
-    default: [],
-    transform: asArray,
-  },
   ignorePath: {
     default: null,
-  },
-  ignorePattern: {
-    default: [],
-    transform: asArray,
   },
   maxWarnings: {
     default: -1,
@@ -75,38 +57,17 @@ const OLD_BASE_CONFIG = {
     default: false,
     transform: negate,
   },
-  parser: {
-    default: null,
-  },
-  parserOptions: {
-    default: {},
-  },
-  plugin: {
-    name: 'plugins',
-    default: [],
-    transform: asArray,
-  },
   quiet: {
-    default: false,
-  },
-  reportUnusedDisableDirectives: {
     default: false,
   },
   resolvePluginsRelativeTo: {
     default: undefined,
-  },
-  rules: {
-    default: {},
   },
   rulesdir: {
     name: 'rulePaths',
     default: [],
     transform: asArray,
   },
-};
-
-const BASE_CONFIG = {
-  ...OLD_BASE_CONFIG,
   config: {
     name: 'overrideConfigFile',
     default: null,
@@ -146,15 +107,13 @@ const BASE_CONFIG = {
   },
 };
 
-/* eslint-disable no-param-reassign */
-const normalizeCliOptions = (rawConfig, newApi) => {
-  const configToUse = newApi ? BASE_CONFIG : OLD_BASE_CONFIG;
-  return Object.keys(configToUse).reduce((config, key) => {
+const normalizeCliOptions = rawConfig => {
+  return Object.keys(BASE_CONFIG).reduce((config, key) => {
     const {
       name = key,
       transform = identity,
       default: defaultValue,
-    } = configToUse[key];
+    } = BASE_CONFIG[key];
 
     const value = rawConfig[key] !== undefined ? rawConfig[key] : defaultValue;
 
@@ -163,12 +122,11 @@ const normalizeCliOptions = (rawConfig, newApi) => {
     return config;
   }, {});
 };
-/* eslint-enable no-param-reassign */
 
-const normalizeConfig = (config, newApi) => {
+const normalizeConfig = config => {
   return {
     ...config,
-    cliOptions: normalizeCliOptions(config.cliOptions || {}, newApi),
+    cliOptions: normalizeCliOptions(config.cliOptions || {}),
   };
 };
 


### PR DESCRIPTION
It looks like the `CLIEngine` code is a vestige of older versions of eslint that this library no longer supports.

Removing that code significantly simplifies the library and will result in a pretty big simplification to https://github.com/jest-community/jest-runner-eslint/pull/176 as well.