### PR TITLE
Fix reporting test durations

### DIFF
--- a/src/runner/runESLint.js
+++ b/src/runner/runESLint.js
@@ -73,6 +73,7 @@ const mkTestResults = ({
       start: startTime,
       end: endTime,
       duration: endTime - startTime,
+      runtime: endTime - startTime,
       slow: false,
     },
     skipped: numPassingTests === 0 && numFailingTests === 0,


### PR DESCRIPTION
Fixes #204.

Jest appears to have changed the format of `TestResult`. What was `perfStats.duration` is now `perfStats.runtime`:

https://github.com/jestjs/jest/blob/edeecfae240bfd54b33f3c9eae156bd157447e5a/packages/jest-test-result/src/types.ts#L90-L122

Adding `runtime` property solves the problem.

I've left the `duration` property in place too in case that provides compatibility with older versions of Jest.