### PR TITLE
Do not report warnings as errors in quiet mode

### DIFF
--- a/integrationTests/__fixtures__/quiet-mode/.eslintrc.json
+++ b/integrationTests/__fixtures__/quiet-mode/.eslintrc.json
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "no-console": "warn"
+  }
+}

--- a/integrationTests/__fixtures__/quiet-mode/__eslint__/file.js
+++ b/integrationTests/__fixtures__/quiet-mode/__eslint__/file.js
@@ -1,0 +1,6 @@
+const a = 1;
+
+console.log('a', a);
+if (a === 2) {
+  hello();
+}

--- a/integrationTests/__fixtures__/quiet-mode/jest-runner-eslint.config.js
+++ b/integrationTests/__fixtures__/quiet-mode/jest-runner-eslint.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  cliOptions: {
+    quiet: true,
+  },
+};

--- a/integrationTests/__fixtures__/quiet-mode/jest.config.js
+++ b/integrationTests/__fixtures__/quiet-mode/jest.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  runner: '../../../',
+  testMatch: ['**/__eslint__/**/*.js'],
+};

--- a/integrationTests/__snapshots__/quiet-mode.test.js.snap
+++ b/integrationTests/__snapshots__/quiet-mode.test.js.snap
@@ -1,0 +1,19 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`does not log warnings as errors in quiet mode 1`] = `
+"FAIL __eslint__/file.js
+  ✕ no-undef 
+
+
+/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/quiet-mode/__eslint__/file.js
+  5:3  error  'hello' is not defined  no-undef
+
+✖ 1 problem (1 error, 0 warnings)
+
+Test Suites: 1 failed, 1 total
+Tests:       1 failed, 1 total
+Snapshots:   0 total
+Time:        
+Ran all test suites.
+"
+`;

--- a/integrationTests/quiet-mode.test.js
+++ b/integrationTests/quiet-mode.test.js
@@ -1,0 +1,5 @@
+const runJest = require('./runJest');
+
+it('does not log warnings as errors in quiet mode', async () => {
+  expect(await runJest('quiet-mode')).toMatchSnapshot();
+});

--- a/src/runner/runESLint.js
+++ b/src/runner/runESLint.js
@@ -234,19 +234,20 @@ const runESLint = async ({ testPath, config, extraOptions }) => {
 
   const end = Date.now();
 
-  const message = await formatter(
-    cliOptions.quiet ? ESLintConstructor.getErrorResults(report) : report,
-  );
+  const eslintReport = cliOptions.quiet
+    ? ESLintConstructor.getErrorResults(report)
+    : report;
+  const message = await formatter(eslintReport);
 
-  if (report[0]?.errorCount > 0) {
+  if (eslintReport[0]?.errorCount > 0) {
     return mkTestResults({
       message,
       start,
       end,
       testPath,
-      numFailingTests: report[0].errorCount,
+      numFailingTests: eslintReport[0].errorCount,
       numPassingTests: 0,
-      assertionResults: mkAssertionResults(testPath, report),
+      assertionResults: mkAssertionResults(testPath, eslintReport),
       cliOptions,
     });
   }


### PR DESCRIPTION
Hello!

This PR addresses issue #211 

When the `quiet` cliOption is passed the call to ESLint's `getErrorResults` filters out warnings, which is expected. Prior to this PR we were using the full list of errors + warnings from ESLint to report the assertions, which incorrectly logged out warnings as error. This PR uses the filtered list instead if `cliOptions.quiet` is specified.

I tested this locally to make sure that it's working as expected, and also verified that the integration test also does not show the warnings.