### PR TITLE
fix: implement fixes to work with eslint 8.57.0

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         node-version: [12.x, 14.x, 16.x, 18.x, 19.x, 20.x]
-        eslint-version: [7, "8.40", 8]
+        eslint-version: [7, "8.40", "8.55", 8]
         jest-version: [27, 28, 29]
         jest-watch-typeahead-version: [1, 2]
         exclude:

--- a/src/runner/runESLint.js
+++ b/src/runner/runESLint.js
@@ -1,31 +1,5 @@
-const { ESLint } = require('eslint');
+const { ESLint, loadESLint } = require('eslint');
 const getESLintOptions = require('../utils/getESLintOptions');
-
-let FlatESLint;
-let shouldUseFlatConfig;
-
-try {
-  // Use a dynamic require here rather than a global require because this
-  // import path does not exist in eslint v7 which this library still
-  // supports
-  //
-  // ESlint exposes the new FlatESLint API under `eslint/use-at-your-own-risk` by
-  // using it's [export configuration](https://tinyurl.com/2s45zh9b).  However,
-  // the `import/no-unresolved` rule is [not aware of
-  // `exports`](https://tinyurl.com/469djpx3) and causes a false error here.  So,
-  // let's ignore that rule for this import.
-  //
-  // eslint-disable-next-line global-require, import/no-unresolved
-  const eslintExperimental = require('eslint/use-at-your-own-risk');
-  FlatESLint = eslintExperimental.FlatESLint;
-  shouldUseFlatConfig = eslintExperimental.shouldUseFlatConfig;
-} catch {
-  /* no-op */
-}
-
-if (shouldUseFlatConfig === undefined) {
-  shouldUseFlatConfig = () => Promise.resolve(false);
-}
 
 /*
  * This function exists because there are issues with the `pass`, `skip`, and
@@ -131,53 +105,26 @@ function removeUndefinedFromObject(object) {
   );
 }
 
-const getESLintConstructor = async () => {
-  if (await shouldUseFlatConfig()) {
-    return FlatESLint;
-  }
-
-  return ESLint;
-};
-
-// Remove options that are not constructor args.
-const getESLintConstructorArgs = async cliOptions => {
-  // these are not constructor args for either the legacy or the flat ESLint
-  // api
-  const { fixDryRun, format, maxWarnings, quiet, ...legacyConstructorArgs } =
-    cliOptions;
-
-  if (await shouldUseFlatConfig()) {
-    // these options are supported by the legacy ESLint api but aren't
-    // supported by the ESLintFlat api
-    const {
-      extensions,
-      ignorePath,
-      rulePaths,
-      resolvePluginsRelativeTo,
-      useEslintrc,
-      overrideConfig,
-      ...flatConstructorArgs
-    } = legacyConstructorArgs;
-    return flatConstructorArgs;
-  }
-
-  return legacyConstructorArgs;
-};
-
 let cachedValues;
 const getCachedValues = async (config, extraOptions) => {
   if (!cachedValues) {
-    const { cliOptions: baseCliOptions } = getESLintOptions(config);
+    const ESLintConstructor = (await loadESLint?.()) ?? ESLint;
+
+    const { cliOptions: baseCliOptions } = getESLintOptions(
+      ESLintConstructor.configType,
+      config,
+    );
     const cliOptions = {
       ...baseCliOptions,
       fix: getComputedFixValue(baseCliOptions),
       ...removeUndefinedFromObject(extraOptions),
     };
 
-    const ESLintConstructor = await getESLintConstructor();
-    const cli = new ESLintConstructor(
-      await getESLintConstructorArgs(cliOptions),
-    );
+    // Remove options that are not constructor args.
+    const { fixDryRun, format, maxWarnings, quiet, ...constructorArgs } =
+      cliOptions;
+
+    const cli = new ESLintConstructor(constructorArgs);
 
     cachedValues = {
       isPathIgnored: cli.isPathIgnored.bind(cli),

--- a/src/runner/runESLint.js
+++ b/src/runner/runESLint.js
@@ -1,5 +1,26 @@
-const { ESLint, loadESLint } = require('eslint');
+const eslint = require('eslint');
 const getESLintOptions = require('../utils/getESLintOptions');
+
+const { ESLint } = eslint;
+let { loadESLint } = eslint;
+
+// loadESLint and ESLint.configType were added in eslint v8.57.0.  The block
+// below is some compat code to make this library work with flat config and
+// versions of eslint prior to 8.57.0.
+if (!loadESLint) {
+  try {
+    const {
+      FlatESLint,
+      shouldUseFlatConfig,
+      // eslint-disable-next-line global-require, import/no-unresolved
+    } = require('eslint/use-at-your-own-risk');
+    FlatESLint.configType = 'flat';
+    loadESLint = async () =>
+      (await shouldUseFlatConfig?.()) ? FlatESLint : ESLint;
+  } catch {
+    /* no-op */
+  }
+}
 
 /*
  * This function exists because there are issues with the `pass`, `skip`, and

--- a/src/utils/__tests__/normalizeConfig.test.js
+++ b/src/utils/__tests__/normalizeConfig.test.js
@@ -1,7 +1,7 @@
 const normalizeConfig = require('../normalizeConfig');
 
-const normalizeCLIOptions = cliOptions =>
-  normalizeConfig({ cliOptions }).cliOptions;
+const normalizeCLIOptions = (cliOptions, configType) =>
+  normalizeConfig(configType, { cliOptions }).cliOptions;
 
 it('ignores unknown options', () => {
   expect(normalizeCLIOptions({ other: true })).not.toMatchObject({

--- a/src/utils/getESLintOptions.js
+++ b/src/utils/getESLintOptions.js
@@ -3,14 +3,14 @@ const normalizeConfig = require('./normalizeConfig');
 
 const explorer = cosmiconfigSync('jest-runner-eslint');
 
-const getESLintOptions = config => {
+const getESLintOptions = (configType, config) => {
   const result = explorer.search(config.rootDir);
 
   if (result) {
-    return normalizeConfig(result.config);
+    return normalizeConfig(configType, result.config);
   }
 
-  return normalizeConfig({});
+  return normalizeConfig(configType, {});
 };
 
 module.exports = getESLintOptions;

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -21,11 +21,6 @@ const BASE_CONFIG = {
   cacheLocation: {
     default: '.eslintcache',
   },
-  ext: {
-    name: 'extensions',
-    default: ['.js'],
-    transform: asArray,
-  },
   fix: {
     default: false,
   },
@@ -35,17 +30,9 @@ const BASE_CONFIG = {
   format: {
     default: undefined,
   },
-  ignorePath: {
-    default: null,
-  },
   maxWarnings: {
     default: -1,
     transform: asInt,
-  },
-  noEslintrc: {
-    name: 'useEslintrc',
-    default: false,
-    transform: negate,
   },
   noIgnore: {
     name: 'ignore',
@@ -60,16 +47,36 @@ const BASE_CONFIG = {
   quiet: {
     default: false,
   },
-  resolvePluginsRelativeTo: {
-    default: undefined,
+  config: {
+    name: 'overrideConfigFile',
+    default: null,
+  },
+};
+
+const LEGACY_CONFIG = {
+  ...BASE_CONFIG,
+  ext: {
+    name: 'extensions',
+    default: ['.js'],
+    transform: asArray,
+  },
+  ignorePath: {
+    default: null,
   },
   rulesdir: {
     name: 'rulePaths',
     default: [],
     transform: asArray,
   },
-  config: {
-    name: 'overrideConfigFile',
+  resolvePluginsRelativeTo: {
+    default: undefined,
+  },
+  noEslintrc: {
+    name: 'useEslintrc',
+    default: false,
+    transform: negate,
+  },
+  reportUnusedDisableDirectives: {
     default: null,
   },
   env: {
@@ -98,22 +105,28 @@ const BASE_CONFIG = {
     default: [],
     transform: asArray,
   },
-  reportUnusedDisableDirectives: {
-    default: null,
-  },
   rules: {
     name: 'overrideConfig.rules',
     default: {},
   },
 };
 
-const normalizeCliOptions = rawConfig => {
-  return Object.keys(BASE_CONFIG).reduce((config, key) => {
+const FLAT_CONFIG = {
+  ...BASE_CONFIG,
+  reportUnusedDisableDirectives: {
+    name: 'overrideConfig.linterOptions.reportUnusedDisableDirectives',
+    default: false,
+  },
+};
+
+const normalizeCliOptions = (configType, rawConfig) => {
+  const configConfig = configType === 'flat' ? FLAT_CONFIG : LEGACY_CONFIG;
+  return Object.keys(configConfig).reduce((config, key) => {
     const {
       name = key,
       transform = identity,
       default: defaultValue,
-    } = BASE_CONFIG[key];
+    } = configConfig[key];
 
     const value = rawConfig[key] !== undefined ? rawConfig[key] : defaultValue;
 
@@ -123,10 +136,10 @@ const normalizeCliOptions = rawConfig => {
   }, {});
 };
 
-const normalizeConfig = config => {
+const normalizeConfig = (configType, config) => {
   return {
     ...config,
-    cliOptions: normalizeCliOptions(config.cliOptions || {}),
+    cliOptions: normalizeCliOptions(configType, config.cliOptions || {}),
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1023,18 +1023,18 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@eslint/js@8.55.0":
-  version "8.55.0"
-  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.55.0.tgz#b721d52060f369aa259cf97392403cb9ce892ec6"
-  integrity sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==
+"@eslint/js@8.57.0":
+  version "8.57.0"
+  resolved "https://registry.yarnpkg.com/@eslint/js/-/js-8.57.0.tgz#a5417ae8427873f1dd08b70b3574b453e67b5f7f"
+  integrity sha512-Ys+3g2TaW7gADOJzPt83SJtCDhMjndcDMFVQ/Tj9iA1BfJzFKD9mAUXT3OenpuPHbI6P/myECxRJrofUsDx/5g==
 
-"@humanwhocodes/config-array@^0.11.13":
-  version "0.11.13"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.13.tgz#075dc9684f40a531d9b26b0822153c1e832ee297"
-  integrity sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==
+"@humanwhocodes/config-array@^0.11.14":
+  version "0.11.14"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/config-array/-/config-array-0.11.14.tgz#d78e481a039f7566ecc9660b4ea7fe6b1fec442b"
+  integrity sha512-3T8LkOmg45BV5FICb15QQMsyUSWrQ8AygVfC7ZG32zOalnqrilm018ZVCw0eapXux8FtA33q8PSRSstjee3jSg==
   dependencies:
-    "@humanwhocodes/object-schema" "^2.0.1"
-    debug "^4.1.1"
+    "@humanwhocodes/object-schema" "^2.0.2"
+    debug "^4.3.1"
     minimatch "^3.0.5"
 
 "@humanwhocodes/module-importer@^1.0.1":
@@ -1042,10 +1042,10 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz#af5b2691a22b44be847b0ca81641c5fb6ad0172c"
   integrity sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==
 
-"@humanwhocodes/object-schema@^2.0.1":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz#e5211452df060fa8522b55c7b3c0c4d1981cb044"
-  integrity sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==
+"@humanwhocodes/object-schema@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-2.0.2.tgz#d9fae00a2d5cb40f92cfe64b47ad749fbc38f917"
+  integrity sha512-6EwiSjwWYP7pTckG6I5eyFANjPhmPjUX9JRLUSfNPC7FX7zK9gyZAfUEaECL6ALTpGX5AjnBq3C9XmVWPitNpw==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.1.0"
@@ -1494,9 +1494,9 @@ acorn-jsx@^5.3.2:
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
 acorn@^8.9.0:
-  version "8.11.2"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.2.tgz#ca0d78b51895be5390a5903c5b3bdcdaf78ae40b"
-  integrity sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==
+  version "8.11.3"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
+  integrity sha512-Y9rRfJG5jcKOE0CLisYbojUjIrIEE7AGMzA/Sm4BslANhbS+cDMpgBdcPT91oJ7OuJ9hYJBx59RjbhxVnrF8Xg==
 
 ajv@^6.12.4:
   version "6.12.6"
@@ -1988,7 +1988,7 @@ debug@^3.2.7:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.4:
+debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
@@ -2276,15 +2276,15 @@ eslint-visitor-keys@^3.3.0, eslint-visitor-keys@^3.4.1, eslint-visitor-keys@^3.4
   integrity sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==
 
 "eslint@^7 || ^8":
-  version "8.55.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.55.0.tgz#078cb7b847d66f2c254ea1794fa395bf8e7e03f8"
-  integrity sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==
+  version "8.57.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.57.0.tgz#c786a6fd0e0b68941aaf624596fb987089195668"
+  integrity sha512-dZ6+mexnaTIbSBZWgou51U6OmzIhYM2VcNdtiTtI7qPNZm35Akpr0f6vtw3w1Kmn5PYo+tZVfh13WrhpS6oLqQ==
   dependencies:
     "@eslint-community/eslint-utils" "^4.2.0"
     "@eslint-community/regexpp" "^4.6.1"
     "@eslint/eslintrc" "^2.1.4"
-    "@eslint/js" "8.55.0"
-    "@humanwhocodes/config-array" "^0.11.13"
+    "@eslint/js" "8.57.0"
+    "@humanwhocodes/config-array" "^0.11.14"
     "@humanwhocodes/module-importer" "^1.0.1"
     "@nodelib/fs.walk" "^1.2.8"
     "@ungap/structured-clone" "^1.2.0"
@@ -2425,9 +2425,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fastq@^1.6.0:
-  version "1.15.0"
-  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.15.0.tgz#d04d07c6a2a68fe4599fea8d2e103a937fae6b3a"
-  integrity sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/fastq/-/fastq-1.17.1.tgz#2a523f07a4e7b1e81a42b91b8bf2254107753b47"
+  integrity sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==
   dependencies:
     reusify "^1.0.4"
 
@@ -2478,9 +2478,9 @@ flat-cache@^3.0.4:
     rimraf "^3.0.2"
 
 flatted@^3.2.9:
-  version "3.2.9"
-  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.2.9.tgz#7eb4c67ca1ba34232ca9d2d93e9886e611ad7daf"
-  integrity sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.3.1.tgz#21db470729a6734d4997002f439cb308987f567a"
+  integrity sha512-X8cqMLLie7KsNUDSdzeN8FYK9rEt4Dt67OsG/DNGnYTSDBG4uFAJFBnUeiV+zCVAvwFy56IjM9sH51jVaEhNxw==
 
 for-each@^0.3.3:
   version "0.3.3"
@@ -2594,9 +2594,9 @@ globals@^11.1.0:
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
 
 globals@^13.19.0:
-  version "13.23.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-13.23.0.tgz#ef31673c926a0976e1f61dab4dca57e0c0a8af02"
-  integrity sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==
+  version "13.24.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-13.24.0.tgz#8432a19d78ce0c1e833949c36adb345400bb1171"
+  integrity sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==
   dependencies:
     type-fest "^0.20.2"
 
@@ -2693,9 +2693,9 @@ human-signals@^2.1.0:
   integrity sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==
 
 ignore@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
-  integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.1.tgz#5073e554cd42c5b33b394375f538b8593e34d4ef"
+  integrity sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
This PR implements updates the eslint dependency to 8.57.0 and fixes the error `'reportUnusedDisableDirectives' has been removed. Please use the 'overrideConfig.linterOptions.reportUnusedDisableDirectives' option instead.`.

In doing this, I also made the following improvements:

1. use the new [`loadESLint`](https://eslint.org/docs/latest/integrate/nodejs-api#loadeslint) function to load `ESLint` or `FlatESLint`, rather than using our own logic
2. refactors the `normalizeConfig.js` file to have explicit separate config shapes for the legacy config and the flat config.  This also removes the need to have the code to deal with invalid config variables that we had [here](https://github.com/jest-community/jest-runner-eslint/blob/25a7d38b81c6618230f1f4c5153d639ab8aede08/src/runner/runESLint.js#L149-L162)

Note that #1 makes this library incompatible with using the flat config format with eslint < 8.57.0.  But I think that's OK given that 1) the flat config was experimental anyways and 2) if someone had a use case for locking eslint < 8.57.0, they could just as easily also lock jest-runner-eslint to v2.1.2.  It's technically a breaking change, but I don't think it absolutely must be marked as such.