### PR TITLE
chore: skip tests with Jest 28 and Node 18

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -30,6 +30,8 @@ jobs:
           - node-version: 12
             jest-watch-typeahead-version: 2
           # Modern timers need Jest 29.2.1 on Node 19+: https://github.com/facebook/jest/pull/13467
+          - node-version: 18.x
+            jest-version: 28
           - node-version: 19.x
             jest-version: 28
           - node-version: 20.x

--- a/src/utils/normalizeConfig.js
+++ b/src/utils/normalizeConfig.js
@@ -99,7 +99,8 @@ const BASE_CONFIG = {
     transform: asArray,
   },
   reportUnusedDisableDirectives: {
-    default: null,
+    name: 'overrideConfig.reportUnusedDisableDirectives',
+    default: false,
   },
   rules: {
     name: 'overrideConfig.rules',


### PR DESCRIPTION
Node 18.19 backported whatever v8 change that breaks fake timers in Jest 28, so we need to skip that combo on CI