### PR TITLE
test: use `toThrow` instead of `toThrowError`

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,8 @@
     "ecmaVersion": 11
   },
   "rules": {
-    "no-underscore-dangle": 0
+    "no-underscore-dangle": 0,
+    "jest/no-alias-methods": 1
   },
   "env": {
     "jest/globals": true

--- a/src/utils/__tests__/normalizeConfig.test.js
+++ b/src/utils/__tests__/normalizeConfig.test.js
@@ -118,7 +118,7 @@ it('normalizes maxWarnings', () => {
     maxWarnings: 10,
   });
 
-  expect(() => normalizeCLIOptions({ maxWarnings: 'not-an-int' })).toThrowError(
+  expect(() => normalizeCLIOptions({ maxWarnings: 'not-an-int' })).toThrow(
     `'not-an-int' cannot be converted to a number`,
   );
 });


### PR DESCRIPTION
This alias has been removed in Jest v30