### PR TITLE
test: update snapshot header link based on Jest version

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -67,6 +67,6 @@ jobs:
           cache: yarn
       - name: install with eslint v${{ matrix.eslint-version }}, jest@${{ matrix.jest-version }}, and jest-watch-typeahead@${{ matrix.jest-watch-typeahead-version }}
         run: yarn add --dev eslint@${{ matrix.eslint-version }} jest@${{ matrix.jest-version }} babel-jest@${{ matrix.jest-version }} jest-watch-typeahead@${{ matrix.jest-watch-typeahead-version }} --ignore-engines
-      - run: node update-snapshot-links.js
+      - run: node update-snapshots.js
       - name: run tests
         run: yarn test

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -67,5 +67,6 @@ jobs:
           cache: yarn
       - name: install with eslint v${{ matrix.eslint-version }}, jest@${{ matrix.jest-version }}, and jest-watch-typeahead@${{ matrix.jest-watch-typeahead-version }}
         run: yarn add --dev eslint@${{ matrix.eslint-version }} jest@${{ matrix.jest-version }} babel-jest@${{ matrix.jest-version }} jest-watch-typeahead@${{ matrix.jest-watch-typeahead-version }} --ignore-engines
+      - run: node update-snapshot-links.js
       - name: run tests
         run: yarn test

--- a/integrationTests/__snapshots__/custom-parser.test.js.snap
+++ b/integrationTests/__snapshots__/custom-parser.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Doesn't override parser when not set [ESLint=7] 1`] = `
 "FAIL __eslint__/file.js

--- a/integrationTests/__snapshots__/failing.test.js.snap
+++ b/integrationTests/__snapshots__/failing.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Works when it has failing tests 1`] = `
 "FAIL __eslint__/file.js

--- a/integrationTests/__snapshots__/flat-config.test.js.snap
+++ b/integrationTests/__snapshots__/flat-config.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Works with the new flat config format 1`] = `
 "FAIL __eslint__/file.js

--- a/integrationTests/__snapshots__/format.test.js.snap
+++ b/integrationTests/__snapshots__/format.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Applies custom formatter 1`] = `
 "FAIL __eslint__/file.js

--- a/integrationTests/__snapshots__/github-actions.test.js.snap
+++ b/integrationTests/__snapshots__/github-actions.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Reports with the github actions reporter 1`] = `
 "
-::error file=/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/github-actions/__eslint__/failing.js,line=4,title=no-undef::'hello' is not defined.%0A    at __eslint__/failing.js:4:3
+::error file=/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/github-actions/__eslint__/failing.js,line=4,title=no-undef::'hello' is not defined.%0A%0A    at __eslint__/failing.js:4:3
 
 ::error file=/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/github-actions/__eslint__/failing.js,line=5,title=no-undef::'bye' is not defined.%0A    at __eslint__/failing.js:5:3
 "

--- a/integrationTests/__snapshots__/github-actions.test.js.snap
+++ b/integrationTests/__snapshots__/github-actions.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Reports with the github actions reporter 1`] = `
 "

--- a/integrationTests/__snapshots__/github-actions.test.js.snap
+++ b/integrationTests/__snapshots__/github-actions.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`Reports with the github actions reporter 1`] = `
 "
-::error file=/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/github-actions/__eslint__/failing.js,line=4,title=no-undef::'hello' is not defined.%0A%0A    at __eslint__/failing.js:4:3
+::error file=/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/github-actions/__eslint__/failing.js,line=4,title=no-undef::'hello' is not defined.%0A    at __eslint__/failing.js:4:3
 
-::error file=/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/github-actions/__eslint__/failing.js,line=5,title=no-undef::'bye' is not defined.%0A%0A    at __eslint__/failing.js:5:3
+::error file=/mocked-path-to-jest-runner-mocha/integrationTests/__fixtures__/github-actions/__eslint__/failing.js,line=5,title=no-undef::'bye' is not defined.%0A    at __eslint__/failing.js:5:3
 "
 `;

--- a/integrationTests/__snapshots__/legacy-config-at-eslint.config.js.test.js.snap
+++ b/integrationTests/__snapshots__/legacy-config-at-eslint.config.js.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Does not try to use flat config on eslint versions that don't support it 1`] = `
 "PASS __eslint__/file.js

--- a/integrationTests/__snapshots__/loud.test.js.snap
+++ b/integrationTests/__snapshots__/loud.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Outputs warnings as console messages 1`] = `
 "PASS __eslint__/file.js

--- a/integrationTests/__snapshots__/max-warnings.test.js.snap
+++ b/integrationTests/__snapshots__/max-warnings.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Fails if more than max warnings 1`] = `
 "FAIL __eslint__/file.js

--- a/integrationTests/__snapshots__/passing.test.js.snap
+++ b/integrationTests/__snapshots__/passing.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Works when it has only passing tests 1`] = `
 "PASS __eslint__/file.js

--- a/integrationTests/__snapshots__/quiet-mode.test.js.snap
+++ b/integrationTests/__snapshots__/quiet-mode.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`does not log warnings as errors in quiet mode 1`] = `
 "FAIL __eslint__/file.js

--- a/integrationTests/__snapshots__/skipped.test.js.snap
+++ b/integrationTests/__snapshots__/skipped.test.js.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Works when it has failing tests 1`] = `
 "Test Suites: 1 skipped, 0 of 1 total

--- a/update-snapshot-links.js
+++ b/update-snapshot-links.js
@@ -1,0 +1,20 @@
+const fs = require('fs');
+const semver = require('semver');
+const { version } = require('jest/package.json');
+
+const headerLink = semver.satisfies(version, '30')
+  ? 'https://jestjs.io/docs/snapshot-testing'
+  : 'https://goo.gl/fbAQLP';
+
+for (const file of fs.readdirSync('./integrationTests/__snapshots__')) {
+  const content = fs.readFileSync(
+    `./integrationTests/__snapshots__/${file}`,
+    'utf-8',
+  );
+
+  fs.writeFileSync(
+    `./integrationTests/__snapshots__/${file}`,
+    `// Jest Snapshot v1, ${headerLink}` + content.slice(content.indexOf('\n')),
+    'utf-8',
+  );
+}

--- a/update-snapshots.js
+++ b/update-snapshots.js
@@ -31,7 +31,7 @@ const extraContent = semver.lt(version, '30.1.0') ? '%0A' : '';
 fs.writeFileSync(
   './integrationTests/__snapshots__/github-actions.test.js.snap',
   ghaSnapshotContent
-    .replaceAll('is not defined.%0A%0A', 'is not defined.%0A')
-    .replaceAll('is not defined.%0A', 'is not defined.%0A' + extraContent),
+    .replace(/is not defined.%0A%0A/g, 'is not defined.%0A')
+    .replace(/is not defined.%0A/g, 'is not defined.%0A' + extraContent),
   'utf-8',
 );

--- a/update-snapshots.js
+++ b/update-snapshots.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const semver = require('semver');
 const { version } = require('jest/package.json');
 
+// Jest v30 changed the snapshot header link
 const headerLink = semver.satisfies(version, '30')
   ? 'https://jestjs.io/docs/snapshot-testing'
   : 'https://goo.gl/fbAQLP';
@@ -18,3 +19,19 @@ for (const file of fs.readdirSync('./integrationTests/__snapshots__')) {
     'utf-8',
   );
 }
+
+// Jest v30.1.0 apparently removed a newline from its github actions reporter
+const ghaSnapshotContent = fs.readFileSync(
+  './integrationTests/__snapshots__/github-actions.test.js.snap',
+  'utf-8',
+);
+
+const extraContent = semver.lt(version, '30.1.0') ? '%0A' : '';
+
+fs.writeFileSync(
+  './integrationTests/__snapshots__/github-actions.test.js.snap',
+  ghaSnapshotContent
+    .replaceAll('is not defined.%0A%0A', 'is not defined.%0A')
+    .replaceAll('is not defined.%0A', 'is not defined.%0A' + extraContent),
+  'utf-8',
+);


### PR DESCRIPTION
Jest v30.1.0+ had some changes and fixes relating to snapshots that are causing CI to fail, so this introduces a script that gets run before the test suite to update the snapshots based on the version of Jest being used.

The main change is with the header link, but it seems like there was also a change to the GitHub Actions reporter in v30.1.0 which means it has one less encoded newline in its output and is currently causing CI to fail as we're on v30.0.5 - I've added a condition for this in the script, but that can be removed once we've updated Jest 🤷 